### PR TITLE
fix: Update algolia.md

### DIFF
--- a/docs/content/plugins/search/algolia.md
+++ b/docs/content/plugins/search/algolia.md
@@ -177,7 +177,7 @@ const plugins = [
             ],
           },
           transformer: (product) => ({ 
-            id: product.id, 
+            objectID: product.id, 
             // other attributes...
           }),
         },


### PR DESCRIPTION
## Fix bug where products are not added to Algolia index

Previously, the id property was used as the unique identifier for products in the Algolia index. However, Algolia requires the use of the objectID property as the unique identifier. 

This commit updates the transformer function for the products index to use the objectID property instead of the id property, ensuring that products are properly added to the Algolia index.